### PR TITLE
Verifica .venv antes de ativar nos scripts de hook

### DIFF
--- a/bin/hook-java.sh
+++ b/bin/hook-java.sh
@@ -2,5 +2,9 @@
 set -euo pipefail
 [ -f .env ] && source .env || true
 PKG="${1:-${PKG_DEFAULT:-com.android.settings}}"
+if [ ! -f .venv/bin/activate ]; then
+  echo "Erro: ambiente virtual não disponível" >&2
+  exit 1
+fi
 . .venv/bin/activate
 python scripts/control/control.py -p "$PKG" -s scripts/js/hook_onresume.js --spawn

--- a/bin/hook-native.sh
+++ b/bin/hook-native.sh
@@ -2,5 +2,9 @@
 set -euo pipefail
 [ -f .env ] && source .env || true
 PKG="${1:-${PKG_DEFAULT:-com.android.settings}}"
+if [ ! -f .venv/bin/activate ]; then
+  echo "Erro: ambiente virtual não disponível" >&2
+  exit 1
+fi
 . .venv/bin/activate
 python scripts/control/control.py -p "$PKG" -s scripts/js/native_template.js --spawn


### PR DESCRIPTION
## Sumário
- aborta execução caso `.venv/bin/activate` esteja ausente

## Testes
- `bash -n bin/hook-java.sh bin/hook-native.sh`


------
https://chatgpt.com/codex/tasks/task_e_689e5a1e4c108328b303ad2fc37183dc