### PR TITLE
Hook em onResume armazena função e envia evento

### DIFF
--- a/scripts/js/hook_onresume.js
+++ b/scripts/js/hook_onresume.js
@@ -1,10 +1,10 @@
-// scripts/js/hook_onresume.js
 Java.perform(function () {
   console.log("[*] Java.available =", Java.available);
   var Activity = Java.use("android.app.Activity");
-  Activity.onResume.implementation = function () {
+  var onResume = Activity.onResume;
+  onResume.implementation = function () {
     var cls = this.getClass().getName();
-    var ret = this.onResume();
+    var ret = onResume.call(this);
     send({ev: "onResume", cls: cls});
     return ret;
   };


### PR DESCRIPTION
## Resumo
- Armazena Activity.onResume antes de sobrescrever
- Chama o método original e envia evento após onResume

## Testes
- `node --check scripts/js/hook_onresume.js`


------
https://chatgpt.com/codex/tasks/task_e_689f35a28e508328bff539411cfa4132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the reliability of app resume event monitoring by safely invoking the original resume behavior via a local alias.
  * Preserves existing functionality while reducing the risk of conflicts or unintended overrides during runtime instrumentation, enhancing overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->