### PR TITLE
Refatora hook de Log.d

### DIFF
--- a/scripts/js/rpc_template.js
+++ b/scripts/js/rpc_template.js
@@ -1,5 +1,3 @@
-// scripts/js/rpc_template.js
-// Exemplo de RPC + mensagens
 rpc.exports = {
   ping: function () { return "pong"; },
   toggle: function (flag) {
@@ -12,8 +10,9 @@ var enabled = true;
 
 Java.perform(function () {
   var Log = Java.use('android.util.Log');
-  Log.d.overload('java.lang.String', 'java.lang.String').implementation = function (tag, msg) {
-    var out = this.d(tag, msg);
+  var Log_d = Log.d.overload('java.lang.String', 'java.lang.String');
+  Log_d.implementation = function (tag, msg) {
+    var out = Log_d.call(Log, tag, msg);
     if (enabled) send({ev: 'Log.d', tag: tag.toString(), msg: msg.toString()});
     return out;
   };


### PR DESCRIPTION
## Sumário
- adapta rpc_template.js para usar Log_d.call mantendo envio de eventos

## Testes
- `npm test` *(falhou: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f3ebac8648328b11d5fddc1357c67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reworked internal logging integration to improve reliability and maintain consistent behavior across environments. No user-visible changes or command interface changes.
* **Chores**
  * Removed obsolete header comments for cleaner source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->