### PR TITLE
Handle spawn gating when spawning

### DIFF
--- a/scripts/control/control.py
+++ b/scripts/control/control.py
@@ -92,9 +92,10 @@ def main():
             PIDS.add(target.pid)
         elif args.spawn:
             pid = device.spawn([PKG])
-            sess = device.attach(pid)
-            load_scripts(sess, scripts)
-            device.resume(pid)
+            if not args.spawn_gating:
+                sess = device.attach(pid)
+                load_scripts(sess, scripts)
+                device.resume(pid)
             PIDS.add(pid)
 
         print("[+] ready. CTRL+C to exit.")


### PR DESCRIPTION
## Summary
- skip attach/load/resume when spawn gating is active

## Testing
- `python -m py_compile scripts/control/control.py`


------
https://chatgpt.com/codex/tasks/task_e_689f57d87ecc8328a7687db5283e7fe3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a spawn gating mode (via --spawn-gating) that defers post-spawn actions. When enabled, spawned processes are attached, scripts loaded, and resumed later via event handling. Without this flag, immediate post-spawn behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->