### PR TITLE
Adicionar PID aos eventos de log

### DIFF
--- a/scripts/control/control.py
+++ b/scripts/control/control.py
@@ -14,10 +14,10 @@ def log_event(payload):
         OUT.write(json.dumps({"ts": now(), "pkg": PKG, **payload}, ensure_ascii=False) + "\n")
         OUT.flush()
 
-def on_message(message, data):
+def on_message(pid, message, data):
     t = message.get("type")
     if t == "send":
-        log_event(message["payload"])
+        log_event({"pid": pid, **message["payload"]})
     elif t == "error":
         print("[error]", message.get("stack", message))
     else:
@@ -27,7 +27,7 @@ def load_scripts(session, scripts):
     for path in scripts:
         with open(path, "r", encoding="utf-8") as f:
             s = session.create_script(f.read())
-        s.on("message", on_message)
+        s.on("message", lambda m, d: on_message(session.pid, m, d))
         s.load()
 
 def main():


### PR DESCRIPTION
## Resumo
- on_message agora inclui o pid ao registrar eventos
- load_scripts passa session.pid ao callback de mensagens

## Testes
- `python -m py_compile scripts/control/control.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f5a03a9a08328af60a89c0764fae6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Event payloads now include a per-session identifier for “send” messages.
  - Message handling propagates the session identifier across events, improving reliability in multi-session scenarios.
  - Ensures events are consistently scoped to the correct session during interactions.
  - Enhances observability of session-specific activity.
  - No UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->