### PR TITLE
Usar getattr ao buscar processos

### DIFF
--- a/scripts/control/control.py
+++ b/scripts/control/control.py
@@ -83,8 +83,9 @@ def main():
         if args.attach or not args.spawn:
             target = None
             for p in device.enumerate_processes():
-                if p.identifier == PKG or p.name == PKG:
-                    target = p; break
+                if getattr(p, "identifier", "") == PKG or p.name == PKG:
+                    target = p
+                    break
             if not target:
                 print("[!] process not found:", PKG); sys.exit(1)
             sess = device.attach(target.pid)


### PR DESCRIPTION
## Resumo
- evita acessar diretamente `p.identifier` ao procurar por processos
- considera também `p.name` e interrompe a busca somente após coincidência

## Testes
- `python -m py_compile scripts/control/control.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_689f62d3d5cc832891041ff5508a4e1c