### PR TITLE
Handle spawn gating disable on shutdown

### DIFF
--- a/scripts/control/control.py
+++ b/scripts/control/control.py
@@ -106,6 +106,11 @@ def main():
     finally:
         if OUT:
             OUT.close()
+        if args.spawn_gating:
+            try:
+                device.disable_spawn_gating()
+            except Exception:
+                pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- disable spawn gating safely when exiting control script

## Testing
- `python -m py_compile scripts/control/control.py`


------
https://chatgpt.com/codex/tasks/task_e_689f64dbfed88328b17982adbe415f67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior when using spawn gating: the device state is now reliably restored on exit, preventing residual gating from affecting subsequent runs.
  * Reduces the chance of post-exit issues or manual intervention after the script finishes.

* **Chores**
  * Added exit-time cleanup to enhance stability during termination without affecting users who don’t use spawn gating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->