### PR TITLE
Garantir tipos serializáveis na captura de stack

### DIFF
--- a/scripts/js/crypto_policy.js
+++ b/scripts/js/crypto_policy.js
@@ -29,6 +29,16 @@ function bytesToHex(arr, nmax) {
   return out.join("");
 }
 
+function onlySerializable(obj) {
+  var k = Object.keys(obj);
+  for (var i = 0; i < k.length; i++) {
+    var v = obj[k[i]];
+    var t = typeof v;
+    if (t !== "string" && t !== "number" && t !== "boolean" && v !== null) return false;
+  }
+  return true;
+}
+
 Java.perform(function () {
   // Cipher
   try {
@@ -53,7 +63,8 @@ Java.perform(function () {
               inSample: bytesToHex(input, policy.sampleBytes),
               outSample: bytesToHex(out, policy.sampleBytes)});
         if (policy.logStack) {
-          send({ev:"stack", where:"Cipher.doFinal", stack: Java.use("android.util.Log").getStackTraceString(Java.use("java.lang.Exception").$new())});
+          var data = {ev:"stack", where:"Cipher.doFinal", stack: Java.use("android.util.Log").getStackTraceString(Java.use("java.lang.Exception").$new())+""};
+          if (onlySerializable(data)) send(data);
         }
       }
       return out;


### PR DESCRIPTION
## Resumo
- adiciona verificação de serialização antes de enviar a pilha
- converte a stack trace explicitamente para string

## Testes
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f66fc7b748328aa56b688a7693269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of error logging by ensuring payloads are strictly JSON-serializable.
  - Prevented failures when stack data contains non-serializable values, avoiding dropped or malformed logs.
  - Reduced potential app disruptions related to logging edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->