### PR TITLE
Remover importação de Arrays não utilizada

### DIFF
--- a/scripts/js/crypto_policy.js
+++ b/scripts/js/crypto_policy.js
@@ -42,9 +42,8 @@ function onlySerializable(obj) {
 Java.perform(function () {
   // Cipher
   try {
-    var Cipher = Java.use('javax.crypto.Cipher');
-    var Key = Java.use('java.security.Key');
-    var Arrays = Java.use('java.util.Arrays');
+      var Cipher = Java.use('javax.crypto.Cipher');
+      var Key = Java.use('java.security.Key');
 
     var Cipher_init = Cipher.init.overload('int', 'java.security.Key');
     Cipher_init.implementation = function (opmode, key) {


### PR DESCRIPTION
## Resumo
- Remove uso redundante de `java.util.Arrays` em `crypto_policy.js`, simplificando o script de monitoramento de operações criptográficas.

## Testes
- `npm test` *(falhou: não foi possível encontrar package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6b6935cc8328a772952ce25ac564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused initialization in the crypto policy logic to reduce redundant code.
* **Style**
  * Minor indentation and formatting adjustments for improved readability.
* **Refactor**
  * Small cleanup with no change to runtime behavior or functionality.
* **Notes**
  * No changes to public APIs or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->