### PR TITLE
Tornar robusto tratamento de payload no control

### DIFF
--- a/scripts/control/control.py
+++ b/scripts/control/control.py
@@ -26,7 +26,14 @@ def log_event(payload):
             text = str(payload)
             if len(text) > 1024:
                 text = text[:1021] + "..."
-            entry = {"ts": now(), "pkg": PKG, "payload": text}
+            # Preserve campos estruturais mesmo no fallback
+            entry = {"ts": now(), "pkg": PKG}
+            if isinstance(payload, dict):
+                if "pid" in payload:
+                    entry["pid"] = payload["pid"]
+                if "ev" in payload:
+                    entry["ev"] = payload["ev"]
+            entry["payload"] = text
             OUT.write(json.dumps(entry, ensure_ascii=False) + "\n")
         OUT.flush()
 


### PR DESCRIPTION
## Resumo
- evita sobrescrita de metadados ao registrar eventos
- converte payload não serializável em string truncada e marcada com reticências
- valida tipo do payload recebido em `on_message`

## Testes
- `python -m py_compile scripts/control/control.py`


------
https://chatgpt.com/codex/tasks/task_e_689f6b730f04832897632521c7c83dba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of event logging to handle non-JSON-serializable or oversized payloads without errors.
  * Ensures events always include timestamp and package info; preserves key fields from complex payloads in fallback cases.
  * Normalizes message handling so payloads are consistently tagged with PID and logged reliably, reducing telemetry loss and instability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->