### PR TITLE
Garante retomada do processo em falhas de script

### DIFF
--- a/scripts/control/control.py
+++ b/scripts/control/control.py
@@ -101,12 +101,13 @@ def main():
             sess = device.attach(spawn.pid)
             SESSIONS.append(sess)
             load_scripts(sess, scripts)
-            device.resume(spawn.pid)
             PIDS.add(spawn.pid)
             ident = getattr(spawn, "identifier", "?")
             log_event({"ev":"spawn-attached", "pid": int(spawn.pid), "id": ident})
         except Exception as e:
             print("[spawn-handler-error]", e)
+        finally:
+            device.resume(spawn.pid)
 
     if args.spawn_gating:
         device.enable_spawn_gating()
@@ -130,8 +131,10 @@ def main():
             if not args.spawn_gating:
                 sess = device.attach(pid)
                 SESSIONS.append(sess)
-                load_scripts(sess, scripts)
-                device.resume(pid)
+                try:
+                    load_scripts(sess, scripts)
+                finally:
+                    device.resume(pid)
             PIDS.add(pid)
 
         print("[+] ready. CTRL+C to exit.")


### PR DESCRIPTION
## Resumo
- Assegura que `device.resume` seja chamado ao tratar spawns
- Protege carregamento de scripts e retomada em `spawn`

## Testes
- `python -m py_compile scripts/control/control.py`
- `DEVICE_ID=local python scripts/control/control.py -p /bin/ls -s nonexistent.js --spawn` (esperado listar diretório mesmo com erro do script)


------
https://chatgpt.com/codex/tasks/task_e_689f7b06a2148328aed00c928b9d0d10